### PR TITLE
Fix for Heading hold not working.

### DIFF
--- a/Source/VesselData.cs
+++ b/Source/VesselData.cs
@@ -65,7 +65,7 @@ namespace Kramax
             lastPlanetUp = planetUp;
             planetUp = (vessel.rootPart.transform.position - vessel.mainBody.position).normalized;
 //            planetEast = vessel.mainBody.getRFrmVel(vessel.findWorldCenterOfMass()).normalized;
-            planetEast = vessel.mainBody.getRFrmVel(vessel.mainBody.position).normalized;
+            planetEast = vessel.mainBody.getRFrmVel(vessel.GetWorldPos3D()).normalized;
             planetNorth = Vector3d.Cross(planetEast, planetUp).normalized;
 
             // Velocity forward and right vectors parallel to the surface


### PR DESCRIPTION
This should fix the problem of the Heading hold not working.  It is using code from a version that worked in 1.1.2